### PR TITLE
Removed Side argument from Model.playerMove()

### DIFF
--- a/src/BoardModel.java
+++ b/src/BoardModel.java
@@ -3,7 +3,6 @@ import java.util.Arrays;
 /**
  * The BoardModel represents the internal game state of the board and allows manipulation of the board via a player
  * move.
- *
  * @author Andrew Jong
  * @since 14 April 2017
  */
@@ -26,7 +25,7 @@ class BoardModel {
 
 	/**
 	 * Construct a BoardModel object.
-	 * @param pitsPerSide the number of pits (not including mancalas) per side of the board
+	 * @param pitsPerSide          the number of pits (not including mancalas) per side of the board
 	 * @param startingStonesPerPit the number of starting stones in each pit
 	 */
 	public BoardModel(int pitsPerSide, int startingStonesPerPit) {
@@ -37,6 +36,7 @@ class BoardModel {
 	}
 
 	// Because clone() method in Java is bad practice.
+
 	/**
 	 * Copy constructor, Creates a copy of a BoardModel.
 	 * @param copy the BoardModel to copy
@@ -51,28 +51,25 @@ class BoardModel {
 
 	/**
 	 * Process a move for the current player. The player is determined via the board's internal state.
-	 * @param side the side to start on, either BoardModel.SIDE1 or BoardModel.SIDE2
 	 * @param index the index of the pit, from 0 to the number of pits per side (obtainable via the method
-	 *                 getPitsPerSide()).
+	 *              getPitsPerSide()).
 	 */
-	public void playerMove(Side side, int index){
+	public void playerMove(int index) {
 		/* Argument checking. */
 		// index must be within board bounds.
 		if (index < 0 || index >= player1Pits.length) {
 			throw new IllegalArgumentException("Requested index out of board bounds, must be between 0 and " +
-					(player1Pits.length- 1) + ". Received " + index);
+					(player1Pits.length - 1) + ". Received " + index);
 		}
 
 		/* Determine the correct location of the move and pick up the stones */
-		boolean onSide1; // boolean for remembering which side the stones will go
+		boolean onSide1 = player1Turn; // boolean for remembering which side the stones will go
 		int numStones;
-		if (side == Side.P1) {
-			onSide1 = true;
+		if (onSide1) {
 			// pick up the stones from side 1
 			numStones = player1Pits[index];
 			player1Pits[index] = 0;
 		} else {
-			onSide1 = false;
 			// pick up the stones from side 2
 			numStones = player2Pits[index];
 			player2Pits[index] = 0;
@@ -107,7 +104,7 @@ class BoardModel {
 		int landedPit = nextPit - 1;
 		// can capture if the pit landed is within range, on the player's side, and pit landed in is empty
 		boolean withinRange = landedPit >= 0 && landedPit < player1Pits.length;
-		if (withinRange){
+		if (withinRange) {
 			boolean onPlayerSide = onSide1 == player1Turn;
 			// landed pit was empty if the only stone was the last stone placed (1)
 			boolean landedPitEmpty = (onSide1 && player1Pits[landedPit] == 1)
@@ -146,8 +143,8 @@ class BoardModel {
 	 * @return true if stones empty, false if has stones
 	 */
 	public boolean allPitsEmpty() {
-		for (int i : player1Pits) if (i!=0) return false;
-		for (int i : player2Pits) if (i!=0) return false;
+		for (int i : player1Pits) if (i != 0) return false;
+		for (int i : player2Pits) if (i != 0) return false;
 		return true;
 	}
 

--- a/src/Controller.java
+++ b/src/Controller.java
@@ -114,15 +114,21 @@ public class Controller {
 		public void mousePressed(MouseEvent e) {
 			Point clickPoint = e.getPoint();
 			System.out.println(clickPoint.getX() + "," + clickPoint.getY());
-			if (pitPanel.getShape().contains(clickPoint)) {
-				System.out.println("side[" + side + "], pit " + pitNumber + " clicked");
-				try {
-					gameModel.playerMove(side, pitNumber);
-				} catch (GameModel.GameFinishedException e1) {
-					// TODO Auto-generated catch block
-					e1.printStackTrace();
+			boolean correctSide = side.isP1Side() == gameModel.getCurrentBoardData().PLAYER_1_TURN;
+			if (correctSide) {
+				if (pitPanel.getShape().contains(clickPoint)) {
+					System.out.println("side[" + side + "], pit " + pitNumber + " clicked");
+					try {
+						gameModel.playerMove(pitNumber);
+					} catch (GameModel.GameFinishedException e1) {
+						// TODO Auto-generated catch block
+						e1.printStackTrace();
+					}
 				}
+			} else {
+				System.out.println("Player cannot click me, I belong to the opponent.");
 			}
+
 		}
 		
 		/** When mouse is over a pit, displays a tooltip containing the number of stones in the pit */
@@ -184,7 +190,9 @@ public class Controller {
 
 			System.out.println("side[" + side + "], panel " + index + " clicked");
 			try {
-				gameModel.playerMove(side, index);
+				boolean correctSide = side.isP1Side() == gameModel.getCurrentBoardData().PLAYER_1_TURN;
+				if (correctSide)
+					gameModel.playerMove(index);
 			} catch (GameModel.GameFinishedException e1) {
 				// TODO Auto-generated catch block
 				e1.printStackTrace();

--- a/src/GameModel.java
+++ b/src/GameModel.java
@@ -5,7 +5,6 @@ import java.util.*;
 /**
  * The GameModel represents handles the game loop and state. It also handles updates to its internal state
  * and notifies its ChangeListeners of changes.
- *
  * @author Andrew Jong
  * @since 14 April 2017
  */
@@ -80,22 +79,19 @@ public class GameModel {
 
 	/**
 	 * Calls BoardModel.playerMove(side, index) while updating the undo history and listeners.
-	 *
-	 * @param side the side to start on, either GameModel.SIDE1 or GameModel.SIDE2
 	 * @param index the index of the pit, from 0 to the number of pits per side (obtainable via the method
-	 *                 getPitsPerSide()).
-	 * @throws GameFinishedException execpetion to be thrown if the game is finished. See isGameFinished() to get
-	 * the state of game completion.
-	 *
+	 *              getPitsPerSide()).
+	 * @throws GameFinishedException execpetion to be thrown if the game is finished. See isGameFinished() to get the
+	 *                               state of game completion.
 	 */
-	public void playerMove(Side side, int index) throws GameFinishedException {
+	public void playerMove(int index) throws GameFinishedException {
 		if (gameFinished) throw new GameFinishedException();
 
 		redoHistory.clear(); // Reset the redo history
 		undoHistory.push(new BoardModel(currentBoard)); // Store the current board in undo history before updating.
 		if (undoHistory.size() > MAX_UNDO_DEPTH) numUndos = 0;
 
-		currentBoard.playerMove(side, index); // update the current board
+		currentBoard.playerMove(index); // update the current board
 
 		checkGameFinished();
 
@@ -109,7 +105,8 @@ public class GameModel {
 	/**
 	 * Exception to be thrown if the game is finished. If the game is finished, no additional moves can be made.
 	 */
-	static class GameFinishedException extends Exception{}
+	static class GameFinishedException extends Exception {
+	}
 
 	/**
 	 * A static nested class for the undo() and redo() methods if there is nothing left in the history.
@@ -123,7 +120,8 @@ public class GameModel {
 	/**
 	 * A static nested class for the undo() method if the player has reached the maximum number of numUndos.
 	 */
-	static class MaxUndosReachedException extends Exception {}
+	static class MaxUndosReachedException extends Exception {
+	}
 
 	/**
 	 * Undo by popping the undo history stack to replace the curent board.
@@ -147,7 +145,7 @@ public class GameModel {
 	 * Undo by popping the redo history stack to replace the curent board.
 	 * @throws EmptyHistoryException redo history is empty
 	 */
-	public void redo() throws EmptyHistoryException{
+	public void redo() throws EmptyHistoryException {
 		if (redoHistory.isEmpty()) {
 			throw new EmptyHistoryException("The redo history is empty. No more redos available.");
 		}
@@ -199,7 +197,7 @@ public class GameModel {
 	 * Get a representation of the BoardData of the board on the current turn.
 	 * @return an instance of BoardData representing the state of the current board.
 	 */
-	public BoardData getCurrentBoardData(){
+	public BoardData getCurrentBoardData() {
 		return new BoardData(currentBoard);
 	}
 

--- a/src/Side.java
+++ b/src/Side.java
@@ -4,5 +4,15 @@
  * Meant to be used as the first argument to the playerMove() method.
  */
 public enum Side {
-	P1, P2
+	P1(true), P2(false);
+
+	private boolean p1Side;
+
+	Side(boolean b) {
+		p1Side = b;
+	}
+
+	public boolean isP1Side() {
+		return p1Side;
+	}
 }

--- a/tests/BoardModelTest.java
+++ b/tests/BoardModelTest.java
@@ -14,7 +14,7 @@ public class BoardModelTest {
 	void testPlayerMoveBadIndexArgumentException() {
 		BoardModel model = new BoardModel(6, 4);
 		try {
-			model.playerMove(Side.P2, 11);
+			model.playerMove(11);
 		} catch (IllegalArgumentException e) {
 			String expectedErrorMessage = "Requested index out of board bounds, must be between 0 and 5. Received " +
 					11;
@@ -26,30 +26,30 @@ public class BoardModelTest {
 	void testYesTurnToggleAfterLandInCentralGrid() {
 		BoardModel model = new BoardModel(6, 4);
 		assertEquals(true, model.isPlayer1Turn());
-		model.playerMove(Side.P1, 0);
+		model.playerMove(0);
 		assertEquals(false, model.isPlayer1Turn());
 	}
 
 	@Test
-	void testYesTurnToggleAfterLandInOpponentMancala() {
-		BoardModel model = new BoardModel(6, 4);
+	void testNoContinueTurnWhenLandInOpponentMancala() {
+		BoardModel model = new BoardModel(6, 8);
 		assertEquals(true, model.isPlayer1Turn());
-		model.playerMove(Side.P2, 2);
+		model.playerMove(6);
 		assertEquals(false, model.isPlayer1Turn());
 	}
 
 	@Test
-	void testNoTurnToggleAfterLandInOwnMancala() {
+	void testYesContinueTurnWhenLandInOwnMancala() {
 		BoardModel model = new BoardModel(6, 4);
 		assertEquals(true, model.isPlayer1Turn());
-		model.playerMove(Side.P1, 2);
+		model.playerMove(2);
 		assertEquals(true, model.isPlayer1Turn());
 	}
 
 	@Test
 	void testCorrectStonePlacementP1LandInP1Mancala() {
 		BoardModel model = new BoardModel(6, 4);
-		model.playerMove(Side.P1, 2);
+		model.playerMove(2);
 
 		int[] expectedP1Pits = {4, 4, 0, 5, 5, 5};
 		assertTrue(Arrays.equals(expectedP1Pits, model.getPlayer1Pits()));
@@ -64,7 +64,7 @@ public class BoardModelTest {
 	@Test
 	void testCorrectStonePlacementP1MoveToP2Side() {
 		BoardModel model = new BoardModel(6, 4);
-		model.playerMove(Side.P1, 3);
+		model.playerMove(3);
 
 		int[] expectedP1Pits = {4, 4, 4, 0, 5, 5};
 		assertTrue(Arrays.equals(expectedP1Pits, model.getPlayer1Pits()));
@@ -79,9 +79,9 @@ public class BoardModelTest {
 	@Test
 	void testStoneCaptureP1CaptureP2() {
 		BoardModel model = new BoardModel(6, 4);
-		model.playerMove(Side.P1, 4);
-		model.playerMove(Side.P2, 0);
-		model.playerMove(Side.P1, 0);
+		model.playerMove(4);
+		model.playerMove(0);
+		model.playerMove(0);
 
 		int[] expectedP1Pits = {0, 5, 5, 5, 0, 5};
 		assertTrue(Arrays.equals(expectedP1Pits, model.getPlayer1Pits()));

--- a/tests/BoardModelTest.java
+++ b/tests/BoardModelTest.java
@@ -34,7 +34,7 @@ public class BoardModelTest {
 	void testNoContinueTurnWhenLandInOpponentMancala() {
 		BoardModel model = new BoardModel(6, 8);
 		assertEquals(true, model.isPlayer1Turn());
-		model.playerMove(6);
+		model.playerMove(5);
 		assertEquals(false, model.isPlayer1Turn());
 	}
 

--- a/tests/GameModelTest.java
+++ b/tests/GameModelTest.java
@@ -9,7 +9,7 @@ class GameModelTest {
 	@Test
 	void testCorrectState1Undo() throws GameModel.EmptyHistoryException, GameModel.MaxUndosReachedException, GameModel.GameFinishedException {
 		GameModel model = new GameModel();
-		model.playerMove(Side.P1, 4);
+		model.playerMove(4);
 		model.undo();
 
 		BoardModel expectedStart = new BoardModel(6, 4);
@@ -24,7 +24,7 @@ class GameModelTest {
 
 		boolean caughtSuccessfully = false;
 
-		model.playerMove(Side.P1, 0);
+		model.playerMove(0);
 		try {
 			model.undo();
 		} catch (GameModel.EmptyHistoryException e) {
@@ -32,7 +32,7 @@ class GameModelTest {
 		} catch (GameModel.MaxUndosReachedException e) {
 			throw e;
 		}
-		model.playerMove(Side.P1, 0);
+		model.playerMove(0);
 		try {
 			model.undo();
 		} catch (GameModel.EmptyHistoryException e) {
@@ -40,7 +40,7 @@ class GameModelTest {
 		} catch (GameModel.MaxUndosReachedException e) {
 			throw e;
 		}
-		model.playerMove(Side.P1, 0);
+		model.playerMove(0);
 		try {
 			model.undo();
 		} catch (GameModel.EmptyHistoryException e) {
@@ -48,7 +48,7 @@ class GameModelTest {
 		} catch (GameModel.MaxUndosReachedException e) {
 			throw e;
 		}
-		model.playerMove(Side.P1, 0);
+		model.playerMove(0);
 		try {
 			model.undo();
 		} catch (GameModel.EmptyHistoryException e) {

--- a/tests/GameViewTest.java
+++ b/tests/GameViewTest.java
@@ -11,7 +11,7 @@ public class GameViewTest {
 		GameView view = new GameView(gameModel);
 		
 		try {
-			gameModel.playerMove(Side.P1, 0);
+			gameModel.playerMove(0);
 		} catch (GameModel.GameFinishedException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();


### PR DESCRIPTION
I found out the game specifications say that the player can only move pits on his own side of the board. 

Thus I removed the side argument, and the board assumes the index is for the player's own side.

I modified the Controller to reflect this. It detects whether the side clicked matches the player turn, and will only update the model if this is true.

Passes all tests to my knowledge.